### PR TITLE
Regions in public transport networks in Spain

### DIFF
--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -16793,7 +16793,7 @@
       "tags": {"network": "SMT", "route": "bus"}
     },
     {
-      "displayName": "Servicio Municipal de Transportes Ponderrada",
+      "displayName": "Servicio Municipal de Transportes Ponferrada",
       "id": "smt-cbced8",
       "locationSet": {"include": ["es-le"]},
       "tags": {

--- a/data/transit/route/bus.json
+++ b/data/transit/route/bus.json
@@ -295,7 +295,7 @@
     {
       "displayName": "Álava Bus",
       "id": "alavabus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-vi"]},
       "tags": {
         "network": "Álava Bus",
         "network:wikidata": "Q27969418",
@@ -598,7 +598,7 @@
     {
       "displayName": "AMB Bus Metropolità",
       "id": "ambbusmetropolita-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ct"]},
       "tags": {
         "network": "AMB Bus Metropolità",
         "route": "bus"
@@ -607,7 +607,7 @@
     {
       "displayName": "AMB Nitbus",
       "id": "ambnitbus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ct"]},
       "tags": {
         "network": "AMB Nitbus",
         "route": "bus"
@@ -1298,7 +1298,7 @@
     {
       "displayName": "ATM Lleida",
       "id": "autoritatterritorialdelamobilitatdelareadelleida-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-l"]},
       "tags": {
         "network": "Autoritat Territorial de la Mobilitat de l'Àrea de Lleida",
         "network:short": "ATM Lleida",
@@ -1357,11 +1357,14 @@
       }
     },
     {
-      "displayName": "AUE",
+      "displayName": "Autobusos Urbans d'Elx",
       "id": "aue-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-a"]},
       "tags": {
-        "network": "AUE",
+        "network": "Autobusos Urbans d'Elx",
+        "network:short": "AUE",
+        "operator": "Avanza",
+        "operator:wikidata": "Q56316715",
         "network:wikidata": "Q5712413",
         "route": "bus"
       }
@@ -1416,7 +1419,7 @@
     {
       "displayName": "Autobuses Urbanos de Almería",
       "id": "autobusesurbanosdealmeria-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-al"]},
       "tags": {
         "network": "Autobuses Urbanos de Almería",
         "route": "bus"
@@ -1436,7 +1439,7 @@
     {
       "displayName": "Autobuses Urbanos de Córdoba",
       "id": "autobusesurbanosdecordoba-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-co"]},
       "tags": {
         "network": "Autobuses Urbanos de Córdoba",
         "route": "bus"
@@ -1457,7 +1460,7 @@
     {
       "displayName": "Autobuses Urbanos de Granada",
       "id": "autobusesurbanosdegranada-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-gr"]},
       "tags": {
         "network": "Autobuses Urbanos de Granada",
         "network:wikidata": "Q5712425",
@@ -1467,7 +1470,7 @@
     {
       "displayName": "Autobuses Urbanos de Jerez",
       "id": "autobusesurbanosdejerez-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ca"]},
       "tags": {
         "network": "Autobuses Urbanos de Jerez",
         "network:wikidata": "Q48781656",
@@ -1477,7 +1480,7 @@
     {
       "displayName": "Autobuses Urbanos de León",
       "id": "autobusesurbanosdeleon-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-le"]},
       "tags": {
         "network": "Autobuses Urbanos de León",
         "network:wikidata": "Q18195802",
@@ -1498,7 +1501,7 @@
     {
       "displayName": "Autobuses Urbanos de Salamanca",
       "id": "autobusesurbanosdesalamanca-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-sa"]},
       "tags": {
         "network": "Autobuses Urbanos de Salamanca",
         "route": "bus"
@@ -1518,7 +1521,7 @@
     {
       "displayName": "Autobuses Urbanos de Segovia",
       "id": "autobusesurbanosdesegovia-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-sg"]},
       "tags": {
         "network": "Autobuses Urbanos de Segovia",
         "network:wikidata": "Q47766692",
@@ -1528,7 +1531,7 @@
     {
       "displayName": "Autobuses Urbanos de Toledo",
       "id": "autobusesurbanosdetoledo-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-to"]},
       "tags": {
         "network": "Autobuses Urbanos de Toledo",
         "route": "bus"
@@ -1548,7 +1551,7 @@
     {
       "displayName": "Autobuses Urbanos de Zamora",
       "id": "autobusesurbanosdezamora-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-za"]},
       "tags": {
         "network": "Autobuses Urbanos de Zamora",
         "route": "bus"
@@ -1568,7 +1571,7 @@
     {
       "displayName": "Autobusos de Lleida",
       "id": "autobusosdelleida-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-l"]},
       "tags": {
         "network": "Autobusos de Lleida",
         "network:wikidata": "Q8209629",
@@ -1621,11 +1624,12 @@
       }
     },
     {
-      "displayName": "Auvasa",
+      "displayName": "AUVASA",
       "id": "auvasa-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-va"]},
       "tags": {
-        "network": "Auvasa",
+        "network": "Autobuses Urbanos de Valladolid",
+        "network:short": "AUVASA",
         "network:wikidata": "Q5712430",
         "route": "bus"
       }
@@ -1633,9 +1637,10 @@
     {
       "displayName": "AUZ",
       "id": "auz-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-z"]},
       "tags": {
-        "network": "AUZ",
+        "network": "Autobuses Urbanos de Zaragoza",
+        "network:short": "AUZ",
         "operator": "Avanza Zaragoza",
         "operator:wikidata": "Q6151783",
         "route": "bus"
@@ -2233,7 +2238,7 @@
     {
       "displayName": "Bilbobus",
       "id": "bilbobus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-bi"]},
       "tags": {
         "network": "Bilbobus",
         "network:wikidata": "Q860494",
@@ -2243,7 +2248,7 @@
     {
       "displayName": "Bizkaibus",
       "id": "bizkaibus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-bi"]},
       "tags": {
         "network": "Bizkaibus",
         "network:wikidata": "Q879270",
@@ -2743,7 +2748,7 @@
     {
       "displayName": "Bus de Palma",
       "id": "busdepalma-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-pm"]},
       "tags": {
         "network": "Bus de Palma",
         "route": "bus"
@@ -2752,7 +2757,7 @@
     {
       "displayName": "Bus de Sabadell",
       "id": "busdesabadell-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "Bus de Sabadell",
         "route": "bus"
@@ -2782,7 +2787,7 @@
     {
       "displayName": "Bus Urbà de Terrassa",
       "id": "busurbadeterrassa-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "Bus Urbà de Terrassa",
         "route": "bus"
@@ -2791,7 +2796,7 @@
     {
       "displayName": "Bus Urbano Cartagena",
       "id": "busurbanocartagena-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
         "network": "Bus Urbano Cartagena",
         "route": "bus"
@@ -4457,7 +4462,7 @@
     {
       "displayName": "Consorcio de Transporte Metropolitano Área de Almería",
       "id": "consorciodetransportemetropolitanoareadealmeria-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-al"]},
       "tags": {
         "network": "Consorcio de Transporte Metropolitano Área de Almería",
         "network:wikidata": "Q5784309",
@@ -4467,7 +4472,7 @@
     {
       "displayName": "Consorcio de Transporte Metropolitano del Área de Granada",
       "id": "consorciodetransportemetropolitanodelareadegranada-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-gr"]},
       "tags": {
         "network": "Consorcio de Transporte Metropolitano del Área de Granada",
         "network:wikidata": "Q5784314",
@@ -4477,7 +4482,7 @@
     {
       "displayName": "Consorcio de Transporte Metropolitano del Campo de Gibraltar",
       "id": "consorciodetransportemetropolitanodelcampodegibraltar-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ca"]},
       "tags": {
         "network": "Consorcio de Transporte Metropolitano del Campo de Gibraltar",
         "network:short": "CTMCG",
@@ -4488,7 +4493,7 @@
     {
       "displayName": "Consorcio de Transportes del Área de Zaragoza",
       "id": "consorciodetransportesdelareadezaragoza-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-z"]},
       "tags": {
         "network": "Consorcio de Transportes del Área de Zaragoza",
         "network:guid": "ES-AR-Z-CTAZ",
@@ -4513,7 +4518,7 @@
     {
       "displayName": "Consorcio Regional de Transportes de Madrid",
       "id": "consorcioregionaldetransportesdemadrid-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-m"]},
       "tags": {
         "network": "Consorcio Regional de Transportes de Madrid",
         "network:short": "CRTM",
@@ -4758,11 +4763,12 @@
       }
     },
     {
-      "displayName": "CTA (Asturias)",
+      "displayName": "Consorcio de Transportes de Asturias",
       "id": "cta-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-as"]},
       "tags": {
-        "network": "CTA",
+        "network": "Consorcio de Transportes de Asturias",
+        "network:short": "CTA",
         "network:wikidata": "Q5784322",
         "route": "bus"
       }
@@ -4802,11 +4808,12 @@
       }
     },
     {
-      "displayName": "CTMAM",
+      "displayName": "Consorcio de Transporte Metropolitano del Área de Málaga",
       "id": "ctmam-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ma"]},
       "tags": {
-        "network": "CTMAM",
+        "network": "Consorcio de Transporte Metropolitano del Área de Málaga",
+        "network:short": "CTMAM",
         "network:wikidata": "Q6949617",
         "route": "bus"
       }
@@ -5015,7 +5022,7 @@
     {
       "displayName": "DBUS",
       "id": "dbus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ss"]},
       "tags": {"network": "DBUS", "route": "bus"}
     },
     {
@@ -8027,7 +8034,7 @@
     {
       "displayName": "Interurbanos de Madrid",
       "id": "interurbanosdemadrid-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-m"]},
       "tags": {
         "network": "Interurbanos de Madrid",
         "route": "bus"
@@ -9860,7 +9867,7 @@
     {
       "displayName": "Lurraldebus",
       "id": "lurraldebus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ss"]},
       "tags": {
         "network": "Lurraldebus",
         "network:wikidata": "Q5984914",
@@ -10242,7 +10249,7 @@
     {
       "displayName": "MataróBus",
       "id": "matarobus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "MataróBus",
         "network:wikidata": "Q6005774",
@@ -10732,14 +10739,17 @@
       }
     },
     {
-      "displayName": "MetroBus (Valencia)",
+      "displayName": "Metrobús",
       "id": "metrobus-a154e2",
       "locationSet": {
         "include": ["es-v.geojson"]
       },
       "tags": {
-        "network": "MetroBus",
+        "network": "Metrobús",
         "network:wikidata": "Q5712403",
+        "operator": "Autoritat de Transport Metropolità de València",
+        "operator:short": "ATMV",
+        "operator:wikidata": "Q26084999",
         "route": "bus"
       }
     },
@@ -11699,7 +11709,7 @@
     {
       "displayName": "Movibus",
       "id": "movibus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
         "network": "Movibus",
         "route": "bus"
@@ -12333,7 +12343,7 @@
     {
       "displayName": "NBus",
       "id": "nbus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-na"]},
       "tags": {
         "network": "NBus",
         "network:wikidata": "Q74445218",
@@ -13277,11 +13287,13 @@
       }
     },
     {
-      "displayName": "Palbus",
+      "displayName": "Autobuses Urbanos de Palencia",
       "id": "palbus-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-p"]},
       "tags": {
-        "network": "Palbus",
+        "network": "Autobuses Urbanos de Palencia",
+        "operator": "PALBUS",
+        "network:wikidata": "Q17622033"
         "route": "bus"
       }
     },
@@ -14824,7 +14836,7 @@
     {
       "displayName": "Reus Transport",
       "id": "reustransport-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "Reus Transport",
         "network:wikidata": "Q9068439",
@@ -16168,7 +16180,7 @@
     {
       "displayName": "Servei Urbà de Sant Cugat del Vallès",
       "id": "serveiurbadesantcugatdelvalles-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "Servei Urbà de Sant Cugat del Vallès",
         "route": "bus"
@@ -16177,9 +16189,11 @@
     {
       "displayName": "Servei Urbà de Viatgers",
       "id": "serveiurbadeviatgers-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-vc"]},
       "tags": {
         "network": "Servei Urbà de Viatgers",
+        "operator": "Autos Vallduxense",
+        "operator:short": "AVSA",
         "route": "bus"
       }
     },
@@ -16779,10 +16793,15 @@
       "tags": {"network": "SMT", "route": "bus"}
     },
     {
-      "displayName": "SMT (Ponferrade)",
+      "displayName": "Servicio Municipal de Transportes Ponderrada",
       "id": "smt-cbced8",
-      "locationSet": {"include": ["es"]},
-      "tags": {"network": "SMT", "route": "bus"}
+      "locationSet": {"include": ["es-le"]},
+      "tags": {
+        "network": "Servicio Municipal de Transportes Ponferrada",
+        "network:short": "SMT",
+        "operator": "LINEcar",
+        "route": "bus"
+      }
     },
     {
       "displayName": "SMTC",
@@ -18091,7 +18110,7 @@
     {
       "displayName": "TAM Interurbano",
       "id": "taminterurbano-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-a"]},
       "matchNames": ["tam alicante interurbano"],
       "tags": {
         "network": "TAM Interurbano",
@@ -18102,7 +18121,7 @@
     {
       "displayName": "TAM Urbano",
       "id": "tamurbano-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-a"]},
       "tags": {
         "network": "TAM Urbano",
         "network:wikidata": "Q15846007",
@@ -18950,7 +18969,7 @@
     {
       "displayName": "TMB",
       "id": "tmb-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ct"]},
       "tags": {
         "network": "TMB",
         "network:wikidata": "Q1778212",
@@ -18958,11 +18977,11 @@
       }
     },
     {
-      "displayName": "TMG XG-642: Metropolitano de Ferrol",
+      "displayName": "Transporte Público de Galicia",
       "id": "tmgxg642metropolitanodeferrol-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ga"]},
       "tags": {
-        "network": "TMG XG-642: Metropolitano de Ferrol",
+        "network": "Transporte Público de Galicia",
         "route": "bus"
       }
     },
@@ -19076,15 +19095,6 @@
       "tags": {
         "network": "TPER",
         "network:wikidata": "Q3997843",
-        "route": "bus"
-      }
-    },
-    {
-      "displayName": "TPG XG-642: Metropolitano de Ferrol",
-      "id": "tpgxg642metropolitanodeferrol-cbced8",
-      "locationSet": {"include": ["es"]},
-      "tags": {
-        "network": "TPG XG-642: Metropolitano de Ferrol",
         "route": "bus"
       }
     },
@@ -19534,7 +19544,7 @@
     {
       "displayName": "Transport de les Illes Balears - Eivissa",
       "id": "transportdelesillesbalearseivissa-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ib"]},
       "tags": {
         "network": "Transport de les Illes Balears - Eivissa",
         "route": "bus"
@@ -19578,7 +19588,7 @@
     {
       "displayName": "Transport públic de Mallorca",
       "id": "transportpublicdemallorca-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ib"]},
       "tags": {
         "network": "Transport públic de Mallorca",
         "route": "bus"
@@ -19587,9 +19597,10 @@
     {
       "displayName": "Transport Públic Generalitat Valenciana",
       "id": "transportpublicgeneralitatvalenciana-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-vc"]},
       "tags": {
         "network": "Transport Públic Generalitat Valenciana",
+        "network:wikidata": "Q134462067",
         "route": "bus"
       }
     },
@@ -19607,18 +19618,18 @@
     {
       "displayName": "Transport Urbà de la Conurbació de Granollers",
       "id": "transporturbadelaconurbaciodegranollers-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-b"]},
       "tags": {
         "network": "Transport Urbà de la Conurbació de Granollers",
         "route": "bus"
       }
     },
     {
-      "displayName": "Transporte de Murcia y Pedanias",
+      "displayName": "Transporte de Murcia y Pedanías",
       "id": "transportedemurciaypedanias-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
-        "network": "Transporte de Murcia y Pedanias",
+        "network": "Transporte de Murcia y Pedanías",
         "network:wikidata": "Q109925389",
         "route": "bus"
       }
@@ -19626,7 +19637,7 @@
     {
       "displayName": "Transporte Metropolitano de Segovia",
       "id": "transportemetropolitanodesegovia-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-sg"]},
       "tags": {
         "network": "Transporte Metropolitano de Segovia",
         "network:wikidata": "Q48781963",
@@ -19646,7 +19657,7 @@
     {
       "displayName": "Transporte Público de Aragón",
       "id": "transportepublicodearagon-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ar"]},
       "tags": {
         "network": "Transporte Público de Aragón",
         "network:short": "TPA",
@@ -19666,7 +19677,7 @@
     {
       "displayName": "Transporte Urbano Cartagena",
       "id": "transporteurbanocartagena-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
         "network": "Transporte Urbano Cartagena",
         "network:wikidata": "Q17631951",
@@ -19676,7 +19687,7 @@
     {
       "displayName": "Transporte urbano de Burgos",
       "id": "transporteurbanodeburgos-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-bu"]},
       "tags": {
         "network": "Transporte urbano de Burgos",
         "network:wikidata": "Q6391113",
@@ -19688,7 +19699,7 @@
     {
       "displayName": "Transporte Urbano de Lorca",
       "id": "transporteurbanodelorca-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
         "network": "Transporte Urbano de Lorca",
         "route": "bus"
@@ -19697,7 +19708,7 @@
     {
       "displayName": "Transporte Urbano de Murcia",
       "id": "transporteurbanodemurcia-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-mc"]},
       "tags": {
         "network": "Transporte Urbano de Murcia",
         "route": "bus"
@@ -19730,7 +19741,7 @@
     {
       "displayName": "Transportes de Gran Canaria",
       "id": "transportesdegrancanaria-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-gc"]},
       "tags": {
         "network": "Transportes de Gran Canaria",
         "route": "bus"
@@ -19765,7 +19776,7 @@
     {
       "displayName": "Transportes Urbanos de Santander",
       "id": "transportesurbanosdesantander-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-s"]},
       "tags": {
         "network": "Transportes Urbanos de Santander",
         "route": "bus"
@@ -19824,7 +19835,7 @@
     {
       "displayName": "Transports Públics de Catalunya",
       "id": "transportspublicsdecatalunya-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ct"]},
       "tags": {
         "network": "Transports Públics de Catalunya",
         "route": "bus"
@@ -19833,7 +19844,7 @@
     {
       "displayName": "Transports públics de Mallorca",
       "id": "transportspublicsdemallorca-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-pm"]},
       "tags": {
         "network": "Transports públics de Mallorca",
         "route": "bus"
@@ -19842,7 +19853,7 @@
     {
       "displayName": "Transports públics de Menorca",
       "id": "transportspublicsdemenorca-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ib"]},
       "tags": {
         "network": "Transports públics de Menorca",
         "route": "bus"
@@ -20216,7 +20227,7 @@
     {
       "displayName": "TUC Pamplona",
       "id": "tucpamplona-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-nc"]},
       "tags": {
         "network": "TUC Pamplona",
         "route": "bus"
@@ -20225,17 +20236,21 @@
     {
       "displayName": "TUC-EHG",
       "id": "tucehg-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-nc"]},
       "tags": {
         "network": "TUC-EHG",
         "route": "bus"
       }
     },
     {
-      "displayName": "TUCS",
+      "displayName": "Transport Urbà de Castelló",
       "id": "tucs-cbced8",
-      "locationSet": {"include": ["es"]},
-      "tags": {"network": "TUCS", "route": "bus"}
+      "locationSet": {"include": ["es-cs"]},
+      "tags": {
+        "network": "Transport Urbà de Castelló",
+        "network:short": "TUCS", 
+        "route": "bus"
+      }
     },
     {
       "displayName": "Tud'Bus",
@@ -20333,7 +20348,7 @@
     {
       "displayName": "TUP",
       "id": "transporteurbanodeponferrada-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-le"]},
       "tags": {
         "network": "Transporte Urbano de Ponferrada",
         "network:short": "TUP",
@@ -20369,7 +20384,7 @@
     {
       "displayName": "TUS (España)",
       "id": "transporteurbanodesantander-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-s"]},
       "tags": {
         "network": "Transporte Urbano de Santander",
         "network:short": "TUS",
@@ -20393,11 +20408,13 @@
       }
     },
     {
-      "displayName": "TUVISA",
+      "displayName": "Transportes Urbanos de Vitoria",
       "id": "tuvisa-cbced8",
       "locationSet": {"include": ["es"]},
       "tags": {
-        "network": "TUVISA",
+        "network": "Transportes Urbanos de Vitoria",
+        "network:eu": "Gasteizko Hiri Garraioa",
+        "network:short": "TUVISA",
         "network:wikidata": "Q536320",
         "route": "bus"
       }
@@ -20672,7 +20689,7 @@
     {
       "displayName": "Urbano Collado Villalba",
       "id": "urbanocolladovillalba-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-m"]},
       "tags": {
         "network": "Urbano Collado Villalba",
         "route": "bus"
@@ -20732,7 +20749,7 @@
     {
       "displayName": "Urbanos de Chiclana",
       "id": "urbanosdechiclana-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-ca"]},
       "tags": {
         "network": "Urbanos de Chiclana",
         "route": "bus"
@@ -20741,7 +20758,7 @@
     {
       "displayName": "Urbanos de Lugo",
       "id": "urbanosdelugo-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-lu"]},
       "tags": {
         "network": "Urbanos de Lugo",
         "route": "bus"
@@ -20750,7 +20767,7 @@
     {
       "displayName": "Urbanos de Ourense",
       "id": "urbanosdeourense-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-or"]},
       "tags": {
         "network": "Urbanos de Ourense",
         "network:wikidata": "Q12401602",
@@ -20760,7 +20777,7 @@
     {
       "displayName": "Urbanos de Talavera",
       "id": "urbanosdetalavera-cbced8",
-      "locationSet": {"include": ["es"]},
+      "locationSet": {"include": ["es-to"]},
       "tags": {
         "network": "Urbanos de Talavera",
         "route": "bus"


### PR DESCRIPTION
Also expanded `transportpublicgeneralitatvalenciana-cbced8` and `metrobus-a154e2`.